### PR TITLE
1.1.1 - added --help and --version switches - fixes issue #3

### DIFF
--- a/bin/toot.bin.js
+++ b/bin/toot.bin.js
@@ -2,6 +2,22 @@
 
 var app = require('../');
 var config = app.config();
+var pkg = require('../package.json');
+var title = pkg.name + ' - ' + pkg.description;
+
+// help and usage message
+var usage = function() {
+  console.log(title);
+  console.log('Usage: toot "message"');
+  console.log('   or: echo "message" | toot');
+  process.exit();
+};
+
+// version message
+var version = function() {
+  console.log(pkg.version);
+  process.exit();
+};
 
 // if we have no config
 if (!config) {
@@ -32,15 +48,16 @@ if (!config) {
     });
 
   } else  if (process.argv.length < 3) {
-    // if insufficient number of arguments
-    console.error('Error: Usage: toot <message>');
-    console.error('   or: echo "message" | toot');
-    process.exit(1);
-  }  else {
+    usage();
+  } else  if (process.argv[2] === '--help') {
+    usage()
+  } else if (process.argv[2] === '--version') {
+    version();
+  } else {
     // send the toot from the command-line argument
     app.toot(config, process.argv[2]).then(function() {
       process.exit(0);
     });
   }
-  
+ 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A command-line Mastodon API utility - toot from the command-line!",
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
Do `toot --help` for help
Do `toot --version` to get the version number