### PR TITLE
Regular expression for instance hostnames accepts hyphens.

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ const getAppDetails = function() {
       domain: {
         description: 'Enter the domain name of your Mastodon instance e.g. mastodon.social',
         type: 'string',
-        pattern: '^[a-z0-9_\.\-:]+$',
+        pattern: '^[a-z0-9_\.:-]+$',
         default: 'mastodon.social',
         required: true
       }


### PR DESCRIPTION
This allows the hostnames of instances to contain hyphens.

Regular expression character classes can only include hyphens to match if they're the first or last character specified in the class. The existing code attempts to get around this by escaping the hyphen, but that doesn't work.